### PR TITLE
Add CAD viewer using three.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-dom": "^19.1.0",
         "tailwind-merge": "^3.3.0",
         "tailwindcss": "^4.1.8",
+        "three": "^0.177.0",
         "tw-animate-css": "^1.3.0"
       }
     },
@@ -6259,6 +6260,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/three": {
+      "version": "0.177.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.177.0.tgz",
+      "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
+      "license": "MIT"
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^19.1.0",
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "^4.1.8",
-    "tw-animate-css": "^1.3.0"
+    "tw-animate-css": "^1.3.0",
+    "three": "^0.177.0"
   }
 }

--- a/src/components/3d/three-view.tsx
+++ b/src/components/3d/three-view.tsx
@@ -1,0 +1,66 @@
+import { useRef, useEffect } from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+
+export default function ThreeView() {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0xf0f0f0);
+
+    const width = containerRef.current.clientWidth;
+    const height = containerRef.current.clientHeight;
+
+    const camera = new THREE.PerspectiveCamera(60, width / height, 0.1, 1000);
+    camera.position.set(5, 5, 5);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(width, height);
+    containerRef.current.appendChild(renderer.domElement);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+
+    const axes = new THREE.AxesHelper(5);
+    scene.add(axes);
+
+    const grid = new THREE.GridHelper(10, 10);
+    scene.add(grid);
+
+    const geometry = new THREE.BoxGeometry();
+    const material = new THREE.MeshNormalMaterial();
+    const cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+
+    const handleResize = () => {
+      if (!containerRef.current) return;
+      const w = containerRef.current.clientWidth;
+      const h = containerRef.current.clientHeight;
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+      renderer.setSize(w, h);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    const animate = () => {
+      renderer.render(scene, camera);
+      controls.update();
+      requestAnimationFrame(animate);
+    };
+    animate();
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      controls.dispose();
+      renderer.dispose();
+      if (containerRef.current) {
+        containerRef.current.removeChild(renderer.domElement);
+      }
+    };
+  }, []);
+
+  return <div ref={containerRef} style={{ width: "100%", height: "500px" }} />;
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -65,6 +65,10 @@ const data = {
         title: "QR Code Generator",
         url: "/general-utilities/qr-code-generator",
       },
+      {
+        title: "CAD Viewer",
+        url: "/cad-viewer",
+      },
     ],
   },
   {

--- a/src/pages/cad-viewer.astro
+++ b/src/pages/cad-viewer.astro
@@ -1,0 +1,23 @@
+---
+import "../styles/globals.css";
+import SidebarLayout from "@/layouts/sidebarLayout";
+import ThreeView from "@/components/3d/three-view";
+
+const breadcrumbItems = [
+  { title: "Home", href: "/" },
+  { title: "CAD Viewer" },
+];
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CAD Viewer</title>
+  </head>
+  <body>
+    <SidebarLayout client:load header={breadcrumbItems}>
+      <ThreeView client:load />
+    </SidebarLayout>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add 3D CAD viewer page and component using three.js
- register CAD viewer in the sidebar navigation
- include three.js dependency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685465e425a0832395273a425d35920e